### PR TITLE
Fix error when clicking on nodes in canvas

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,8 @@ export default class CheckboxSounds extends Plugin {
 		this.addSettingTab(new CheckboxSoundsSettingsTab(this.app, this))
 		this.registerDomEvent(document, 'click', (evt: MouseEvent) => {
 			let nodeAttributes: any = evt.targetNode?.attributes; // find all attributes of said class
+			// Prevents an error when clicking on nodes in Canvas
+			if(nodeAttributes.class === undefined) return;
 			let nodeClasses = nodeAttributes.class.value.split(" ")
 			if (nodeClasses.includes("task-list-item-checkbox")) {
 				// clicked on a checkbox	


### PR DESCRIPTION
I added a check on `nodeAttributes.class` to check if it is undefined and return if it is to prevent an error being raised when accessing data on the class

I have tested it on canvas and this error no longer occurs and other functionality works as normal

![image](https://github.com/yasd251/checkbox-sounds-plugin/assets/54263177/6f5d9068-fa6d-42b0-8545-20b219e0034d)
